### PR TITLE
Remove mentions of `executables_implicit_empty_intf`

### DIFF
--- a/content/tutorial/setup.md
+++ b/content/tutorial/setup.md
@@ -117,7 +117,6 @@ file:
 (name blog)
 (version dev)
 (generate_opam_files)
-(executables_implicit_empty_intf)
 
 (source (github username/blog))
 (license MIT)
@@ -127,26 +126,20 @@ file:
 (package
  (name blog)
  (synopsis "My first blog using YOCaml")
- (description 
-   "My first personal blog using YOCaml for 
+ (description
+   "My first personal blog using YOCaml for
    fun and profit")
  (depends
   (ocaml (>= 5.3.0))))
 ```
 
 The first part of the file outlines how Dune will handle the project —
-essentially configuring the entire project. The two fields that can be
-a bit confusing are:
-
-- `(generate_opam_files)`: This instructs Dune to create the OPAM
-  description files. Dune is just the _build system_, and OPAM is the
-  package manager. This field tells Dune to regenerate the OPAM files,
-  centralizing the project configuration in our `dune-project`.
-
-- `(executables_implicit_empty_intf)`: This automatically creates an
-  empty interface file for executables, allowing the compiler to
-  _track_ unused definitions. In practice, this is recommended, but
-  optional.
+essentially configuring the entire project. The field that can be a
+bit confusing is `(generate_opam_files)`: this instructs Dune to
+create the OPAM description files. Dune is just the _build system_,
+and OPAM is the package manager. This field tells Dune to regenerate
+the OPAM files, centralizing the project configuration in our
+`dune-project`.
 
 The second part of the file specifies additional metadata. The
 _repository_ (here we used [GitHub](https://github.com) as the host)

--- a/content/tutorial/simple-blog-goal.md
+++ b/content/tutorial/simple-blog-goal.md
@@ -42,11 +42,9 @@ knowledge of OCaml**.
 #### About Code Organization
 
 For simplicity, most of the code for our generator will be written in
-a single module, `blog.ml` (no `mli` is needed thanks to the
-`(executables_implicit_empty_intf)` directive in our
-`dune-project`). However, as mentioned several times, YOCaml is just a
-collection of regular packages, so **you are free to organize your
-code however you like**.
+a single module, `blog.ml`. However, as mentioned several times,
+YOCaml is just a collection of regular packages, so **you are free to
+organize your code however you like**.
 
 
 ### Starting point

--- a/dune-project
+++ b/dune-project
@@ -2,7 +2,6 @@
 (name yocaml-www)
 (version dev)
 (generate_opam_files)
-(executables_implicit_empty_intf)
 (using mdx 0.4)
 
 (source (github yocaml/yocaml-www))


### PR DESCRIPTION
> This option is enabled by default starting with Dune lang 3.0.

https://dune.readthedocs.io/en/latest/reference/dune-project/executables_implicit_empty_intf.html